### PR TITLE
use target link libraries instead of deprecated qt5 macro

### DIFF
--- a/mecacellviewer/CMakeLists.txt
+++ b/mecacellviewer/CMakeLists.txt
@@ -45,7 +45,7 @@ set(VIEWSRC
 	${RESOURCES}
 	)
 add_library(mecacellviewer SHARED ${VIEWSRC} ${VIEWHEADERS} ${PRIMHEADERS} ${PLUGINSHEADERS} ${MANAGERSHEADERS} ${RENDERABLESHEADERS} ${UTILITIESHEADERS} ${MENUHEADERS})
-qt5_use_modules(mecacellviewer Quick Core Gui OpenGL)
+target_link_libraries(mecacellviewer Qt5::Quick Qt5::Core Qt5::Gui OpenGL)
 
 install (TARGETS mecacellviewer DESTINATION lib)
 install (FILES ${VIEWHEADERS} DESTINATION include/mecacell/viewer)


### PR DESCRIPTION
`qt5_use_modules` is deprecated and errors for me.

https://stackoverflow.com/questions/31172156/what-to-use-instead-of-qt5-use-modules